### PR TITLE
Add typescript definitions

### DIFF
--- a/generate-ts-def.js
+++ b/generate-ts-def.js
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import { TAG_NAMES } from './lib/tag-names.js';
+
+const typings =
+`import { Component, HTMLAttributes, Props, ReactChild, ReactElement } from 'react';
+
+declare interface ClassComponent<P> {
+  new(...args): Component<P, any>;
+}
+declare interface StatelessComponent<P> {
+  (props: P): ReactElement;
+}
+declare type Children = ReactChild | ReactChild[];
+declare type ReactComponent<P> = ClassComponent<P> | StatelessComponent<P>;
+
+export function hh(tag: string): (selector?: any, properties?: any, children?: Children) => ReactElement;
+export function hh(component: ReactComponent<any>): (selector?: any, properties?: any, children?: Children) => ReactElement;
+
+export function h(tag: string, children?: Children): ReactElement;
+export function h(tag: string, selector: string, children?: Children): ReactElement;
+export function h(tag: string, selector: string, properties: HTMLAttributes, children?: Children): ReactElement;
+export function h(tag: string, properties: HTMLAttributes, children?: Children): ReactElement;
+export function h(component: ReactComponent<any>, children?: Children): ReactElement;
+export function h(component: ReactComponent<any>, selector: string, children?: Children): ReactElement;
+export function h<P>(component: ReactComponent<P>, selector: string, properties: P & Props<any>, children?: Children): ReactElement;
+export function h<P>(component: ReactComponent<P>, properties: P & Props<any>, children?: Children): ReactElement;
+${
+  TAG_NAMES.reduce((accum, tag) => `${accum}
+export function ${tag}(children?: Children): ReactElement;
+export function ${tag}(selector: string, children?: Children): ReactElement;
+export function ${tag}(selector: string, properties: HTMLAttributes, children?: Children): ReactElement;
+export function ${tag}(properties: HTMLAttributes, children?: Children): ReactElement;`
+  , ``)
+}`;
+
+fs.writeFile('./lib/index.d.ts', typings, (err) => {
+  if (err) {
+    throw err;
+  }
+});

--- a/package.json
+++ b/package.json
@@ -3,9 +3,18 @@
   "version": "1.0.1",
   "description": "Terse syntax for hyperscript using react",
   "main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
   "scripts": {
-    "build": "babel src --out-dir lib",
-    "test": "mocha -c --require babel-core/register ./test",
+    "build": "npm run build:babel && npm run build:ts-def",
+    "build:babel": "babel src --out-dir lib",
+    "build:ts-def": "babel-node ./generate-ts-def.js",
+    "test": "npm run test:mocha && npm run test:tsc",
+    "test:mocha": "mocha -c --require babel-core/register ./test",
+    "test:tsc": "npm run test:tsc:fake-install && npm run test:tsc:compile && npm run test:tsc:cleanup",
+    "test:tsc:clean-fake": "rm -f node_modules/react-hyperscript-helpers",
+    "test:tsc:fake-install": "npm run test:tsc:clean-fake && ln -s .. node_modules/react-hyperscript-helpers",
+    "test:tsc:compile": "tsc test/type-definitions.ts --module commonjs",
+    "test:tsc:cleanup": "npm run test:tsc:clean-fake && rm test/type-definitions.js",
     "prepublish": "npm run clean && npm run build",
     "postversion": "git push && git push --tags",
     "clean": "rimraf lib"
@@ -21,12 +30,14 @@
   "author": "Tyler Graham <tyler.graham.prog@gmail.com>",
   "license": "ISC",
   "devDependencies": {
+    "babel-cli": "^6.5.1",
     "babel-core": "^6.2.1",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-stage-2": "^6.1.18",
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
-    "rimraf": "^2.4.4"
+    "rimraf": "^2.4.4",
+    "typescript": "^1.7.5"
   },
   "peerDependencies": {
     "react": ">=0.13.0 && <=0.15.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,6 @@
 import { createElement } from 'react';
-
-export const TAG_NAMES = [
-  'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base',
-  'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption',
-  'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'dfn', 'dir', 'div', 'dl',
-  'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form',
-  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html',
-  'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'keygen', 'label', 'legend',
-  'li', 'link', 'map', 'mark', 'menu', 'meta', 'nav', 'noscript', 'object',
-  'ol', 'optgroup', 'option', 'p', 'param', 'pre', 'q', 'rp', 'rt', 'ruby', 's',
-  'samp', 'script', 'section', 'select', 'small', 'source', 'span', 'strong',
-  'style', 'sub', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th',
-  'thead', 'title', 'tr', 'u', 'ul', 'video'
-];
+import { TAG_NAMES } from './tag-names.js';
+export { TAG_NAMES };
 
 const isString   = x => typeof x === 'string' && x.length > 0;
 const startsWith = (string, start) => string.indexOf(start) === 0;

--- a/src/tag-names.js
+++ b/src/tag-names.js
@@ -1,0 +1,13 @@
+export const TAG_NAMES = [
+  'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base',
+  'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption',
+  'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'dfn', 'dir', 'div', 'dl',
+  'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html',
+  'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'keygen', 'label', 'legend',
+  'li', 'link', 'main', 'map', 'mark', 'menu', 'meta', 'nav', 'noscript', 'object',
+  'ol', 'optgroup', 'option', 'p', 'param', 'pre', 'q', 'rp', 'rt', 'ruby', 's',
+  'samp', 'script', 'section', 'select', 'small', 'source', 'span', 'strong',
+  'style', 'sub', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th',
+  'thead', 'title', 'tr', 'u', 'ul', 'video'
+];

--- a/test/react-mock.d.ts
+++ b/test/react-mock.d.ts
@@ -1,0 +1,15 @@
+declare module 'react' {
+  export class Component<P, S> {}
+
+  export interface Props<T> {
+    key: number;
+  }
+
+  export interface HTMLAttributes extends Props<any> {
+    ariaHidden: boolean;
+  }
+
+  export type ReactElement = {};
+
+  export type ReactChild = ReactElement;
+}

--- a/test/type-definitions.ts
+++ b/test/type-definitions.ts
@@ -1,0 +1,64 @@
+/// <reference path="./react-mock.d.ts"/>
+import { Component } from 'react';
+import { div, h, hh } from 'react-hyperscript-helpers';
+
+class ClassComponent extends Component<{ foo: string }, any> {}
+const StatelessFunctionComponent = ({ foo }: { foo: string }) => div(`foo: ${foo}`);
+
+const hClassComponent = hh(ClassComponent);
+const hStatelessFunctionComponent = hh(StatelessFunctionComponent);
+const hDiv = hh('div');
+
+export default () => div('.foo', [
+  hClassComponent(),
+  hClassComponent('.selector'),
+  hClassComponent('.selector', [h('span')]),
+  hClassComponent('.selector', {foo: 1, key: 1}, [h('span')]),
+  hClassComponent('.selector', {foo: 1, key: 1}),
+  hClassComponent({foo: 1, key: 1}),
+  hClassComponent([h('span')]),
+  hStatelessFunctionComponent(),
+  hStatelessFunctionComponent('.selector'),
+  hStatelessFunctionComponent('.selector', [h('span')]),
+  hStatelessFunctionComponent('.selector', h('span')),
+  hStatelessFunctionComponent('.selector', {foo: 'bar', key: 1}, [h('span')]),
+  hStatelessFunctionComponent('.selector', {foo: 'bar', key: 1}),
+  hStatelessFunctionComponent({foo: 'bar', key: 1}),
+  hStatelessFunctionComponent([h('span')]),
+  hDiv(),
+  hDiv('.selector'),
+  hDiv('.selector', [h('span')]),
+  hDiv('.selector', h('span')),
+  hDiv('.selector', {ariaHidden: false, key: 1}, [h('span')]),
+  hDiv('.selector', {ariaHidden: false, key: 1}),
+  hDiv({ariaHidden: false, key: 1}),
+  hDiv([h('span')]),
+  h(ClassComponent),
+  h(ClassComponent, '.selector'),
+  h(ClassComponent, '.selector', [h('span')]),
+  h(ClassComponent, '.selector', {foo: 1, key: 1}, [h('span')]),
+  h(ClassComponent, '.selector', {foo: 1, key: 1}),
+  h(ClassComponent, {foo: 1, key: 1}),
+  h(ClassComponent, [h('span')]),
+  h(StatelessFunctionComponent),
+  h(StatelessFunctionComponent, '.selector'),
+  h(StatelessFunctionComponent, '.selector', [h('span')]),
+  h(StatelessFunctionComponent, '.selector', {foo: 'bar', key: 1}, [h('span')]),
+  h(StatelessFunctionComponent, '.selector', {foo: 'bar', key: 1}),
+  h(StatelessFunctionComponent, {foo: 'bar', key: 1}),
+  h(StatelessFunctionComponent, [h('span')]),
+  h('div'),
+  h('div', '.selector'),
+  h('div', '.selector', [h('span')]),
+  h('div', '.selector', {ariaHidden: false, key: 1}, [h('span')]),
+  h('div', '.selector', {ariaHidden: false, key: 1}),
+  h('div', {ariaHidden: false, key: 1}),
+  h('div', [h('span')]),
+  div(),
+  div('.selector'),
+  div('.selector', [h('span')]),
+  div('.selector', {ariaHidden: false, key: 1}, [h('span')]),
+  div('.selector', {ariaHidden: false, key: 1}),
+  div({ariaHidden: false, key: 1}),
+  div([h('span')]),
+]);


### PR DESCRIPTION
Also added `<main>` to tag names.
Moved tag names to their own file so those can be imported without depending on react

Implemented using generate-ts-def from https://github.com/ohanhi/hyperscript-helpers